### PR TITLE
chore: modernize GitHub Actions and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/fix-links.md
+++ b/.github/ISSUE_TEMPLATE/fix-links.md
@@ -1,9 +1,0 @@
----
-name: Proposed link modification
-about: 'Corrected incorrect link.'
-title: ''
-labels: 'fix'
-assignees: ''
----
-
-**Proposed link modification**

--- a/.github/ISSUE_TEMPLATE/fix-links.yml
+++ b/.github/ISSUE_TEMPLATE/fix-links.yml
@@ -1,0 +1,31 @@
+name: Fix a broken link
+description: Report an incorrect or broken link
+labels: ["fix"]
+body:
+  - type: input
+    id: broken-link
+    attributes:
+      label: Broken Link
+      description: The URL that is broken or incorrect
+      placeholder: "https://..."
+    validations:
+      required: true
+  - type: input
+    id: file
+    attributes:
+      label: File containing the link
+      description: Which Markdown file contains this link?
+      placeholder: e.g., ethereum.md
+    validations:
+      required: true
+  - type: input
+    id: corrected-link
+    attributes:
+      label: Corrected Link (optional)
+      description: If you know the correct URL, please provide it
+      placeholder: "https://..."
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context (optional)
+      placeholder: Any additional information about the broken link

--- a/.github/ISSUE_TEMPLATE/list-dapp.md
+++ b/.github/ISSUE_TEMPLATE/list-dapp.md
@@ -1,9 +1,0 @@
----
-name: List a Dapp
-about: Suggest adding a new Dapp to the list
-title: ''
-labels: 'add'
-assignees: ''
----
-
-**Add new Dapp**

--- a/.github/ISSUE_TEMPLATE/list-dapp.yml
+++ b/.github/ISSUE_TEMPLATE/list-dapp.yml
@@ -20,6 +20,7 @@ body:
     id: chain
     attributes:
       label: Blockchain Network
+      multiple: true
       options:
         - Ethereum
         - Arbitrum

--- a/.github/ISSUE_TEMPLATE/list-dapp.yml
+++ b/.github/ISSUE_TEMPLATE/list-dapp.yml
@@ -1,0 +1,57 @@
+name: List a DApp
+description: Suggest adding a new DApp to the list
+labels: ["add"]
+body:
+  - type: input
+    id: name
+    attributes:
+      label: DApp Name
+      placeholder: e.g., Uniswap
+    validations:
+      required: true
+  - type: input
+    id: url
+    attributes:
+      label: Official Website URL
+      placeholder: "https://..."
+    validations:
+      required: true
+  - type: dropdown
+    id: chain
+    attributes:
+      label: Blockchain Network
+      options:
+        - Ethereum
+        - Arbitrum
+        - Avalanche
+        - Base
+        - BSC
+        - Hyperliquid
+        - Ink
+        - Optimism
+        - Plasma
+        - Polygon
+        - Provenance
+        - Solana
+        - Starknet
+        - Sui
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Brief Description
+      placeholder: What does this DApp do?
+    validations:
+      required: true
+  - type: input
+    id: docs
+    attributes:
+      label: Documentation URL (optional)
+      placeholder: "https://docs.example.com"
+  - type: input
+    id: github
+    attributes:
+      label: GitHub URL (optional)
+      placeholder: "https://github.com/..."

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -7,11 +7,14 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   check-pr-title:
     name: Check PR Title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v3.4.0
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -12,5 +12,5 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: actions/checkout@v6
+      - uses: tcort/github-action-markdown-link-check@v1

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -8,6 +8,9 @@ on:
       - main
   pull_request: {}
 
+permissions:
+  contents: read
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- **Upgrade `amannn/action-semantic-pull-request`** from v3.4.0 to v6, and add explicit `permissions: pull-requests: read` for least-privilege security
- **Replace deprecated `gaurav-nelson/github-action-markdown-link-check`** with the actively maintained fork `tcort/github-action-markdown-link-check@v1` (original was deprecated in April 2025)
- **Update `actions/checkout`** from `@master` (unpinned, moving target) to `@v6`
- **Migrate issue templates** from legacy Markdown format (`.md`) to YAML Issue Forms (`.yml`) with structured form fields, required field validation, and a chain dropdown covering all 14 supported networks

## Test plan

- [ ] Verify `Check PR Title` workflow runs successfully on this PR
- [ ] Verify `Check Markdown links` workflow runs successfully on this PR
- [ ] Confirm issue templates render correctly at `https://github.com/YutaSugimura/DeFi-Map/issues/new/choose`

🤖 Generated with [Claude Code](https://claude.com/claude-code)